### PR TITLE
SCRUM-102: refactor docker and storage stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# Market Place local
+uploads/

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,9 +20,9 @@ This project is a Spring Boot application with PostgreSQL as the database. Docke
 To start the application and the PostgreSQL database using Docker Compose, run:
 
 ```bash
-docker-compose --file ./docker/docker-compose.yml up -d
+docker compose --file ./docker/docker-compose.yml up -d
 ```
-This command will:
+This command will do the below:
 
 	•	Build the image (if not already built).
 	•	Start the PostgreSQL database container.
@@ -50,7 +50,7 @@ After making the change, you will access the application at:
   http://localhost:9090/
 
 ```bash
-docker-compose ps
+docker compose ps
 ```
 This command will show the status of your Docker containers.
 
@@ -86,6 +86,6 @@ docker rmi my-app-image
 To stop the running containers, use the following command:
 
 ```bash
-docker-compose --file ./docker/docker-compose.yml down
+docker compose --file ./docker/docker-compose.yml down
 ```
 This command will stop and remove the containers, but the data stored in the PostgreSQL volume will be preserved.

--- a/docker/dbsetup.sql
+++ b/docker/dbsetup.sql
@@ -1,0 +1,3 @@
+create database khutir_craft;
+-- note, we don't care if database exists
+-- psql will just crap out but nothing's gonna happen

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,20 +1,23 @@
+name: "khutir-craft"
 services:
   app:
-    container_name: food-backend
+    container_name: "khutir-app"
     depends_on:
       - db
     environment:
+      # this needs to be overridden to work inside the docker network:
       SPRING_DATASOURCE_URL: "jdbc:postgresql://db:5432/khutir_craft"
     ports:
       - "8080:8080"
     env_file:
+      - ../.env
       - ../.env.local
     build:
       context: ../
       dockerfile: docker/Dockerfile
 
   db:
-    container_name: food-database
+    container_name: "khutir-db"
     image: postgres:16.4-alpine3.20
     restart: always
     environment:
@@ -22,16 +25,19 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pg_marketplace:/var/lib/postgresql/data
-      - ../src/main/sql/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - khutir-db-data:/var/lib/postgresql/data
+      - ./dbsetup.sql:/docker-entrypoint-initdb.d/dbsetup.sql
 
   mail:
-    container_name: mailhog-server
-    image: mailhog/mailhog:v1.0.1
+    container_name: "khutir-mail"
+    image: mailhog/mailhog:latest
     restart: always
     ports:
       - "8025:8025"
       - "1025:1025"
 
 volumes:
-  pg_marketplace:
+  khutir-db-data:
+    name: "khutir-db-data"
+    labels:
+      - "com.khutir-craft.db"

--- a/src/main/java/com/khutircraftubackend/jwt/JwtUtils.java
+++ b/src/main/java/com/khutircraftubackend/jwt/JwtUtils.java
@@ -18,6 +18,7 @@ import java.util.Date;
 public class JwtUtils {
 	
 	private final Algorithm algorithm;
+
 	@Value("${jwt.expiration}")
 	private long jwtExpirationMillis;
 	

--- a/src/main/java/com/khutircraftubackend/storage/CloudinaryService.java
+++ b/src/main/java/com/khutircraftubackend/storage/CloudinaryService.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @RequiredArgsConstructor
-public class CloudinaryServiceImpl implements StorageService {
+public class CloudinaryService implements StorageService {
 	private final Cloudinary cloudinary;
 	
 	@Override

--- a/src/main/java/com/khutircraftubackend/storage/LocalStorageController.java
+++ b/src/main/java/com/khutircraftubackend/storage/LocalStorageController.java
@@ -16,7 +16,7 @@ import java.nio.file.Files;
 @RequiredArgsConstructor
 public class LocalStorageController {
 	public static final String API_PATH = "/v1/resources";
-	public final StorageServiceImpl storageService;
+	public final LocalStorageService storageService;
 	
 	@GetMapping("/{fileName:.+}")
 	@ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/khutircraftubackend/storage/LocalStorageService.java
+++ b/src/main/java/com/khutircraftubackend/storage/LocalStorageService.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Slf4j
-public class StorageServiceImpl implements StorageService {
+public class LocalStorageService implements StorageService {
 	private final String basePath;
 	
 	@Override

--- a/src/main/java/com/khutircraftubackend/storage/config/CloudinaryConfig.java
+++ b/src/main/java/com/khutircraftubackend/storage/config/CloudinaryConfig.java
@@ -5,8 +5,10 @@ import com.cloudinary.utils.ObjectUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("!local")
 public class CloudinaryConfig {
 
     @Value("${cloudinary.cloud_name}")

--- a/src/main/java/com/khutircraftubackend/storage/config/StorageConfig.java
+++ b/src/main/java/com/khutircraftubackend/storage/config/StorageConfig.java
@@ -1,34 +1,35 @@
 package com.khutircraftubackend.storage.config;
 
 import com.cloudinary.Cloudinary;
-import com.khutircraftubackend.storage.CloudinaryServiceImpl;
-import com.khutircraftubackend.storage.StorageServiceImpl;
+import com.khutircraftubackend.storage.CloudinaryService;
+import com.khutircraftubackend.storage.LocalStorageService;
 import com.khutircraftubackend.storage.StorageService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
-@Configuration
 @Slf4j
+@Configuration
+@Import({CloudinaryConfig.class})
 public class StorageConfig {
 	
 	@Bean
 	@Profile("!local")
 	public StorageService cloudinaryService(Cloudinary cloudinary) {
-		
-		return new CloudinaryServiceImpl(cloudinary);
+
+		return new CloudinaryService(cloudinary);
 	}
 	
 	@Bean
 	@Primary
 	@Profile("local")
-	public StorageService localStorageService(
-			@Value("${storage.local.base-path:./uploads}") String basePath) {
-		log.info("Base path: " + basePath);
-		return new StorageServiceImpl(basePath);
+	public StorageService localStorageService(@Value("${storage.local.base-path}") String basePath) {
+		log.info("Local Storage base-path: {}", basePath);
+		return new LocalStorageService(basePath);
 	}
 	
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,17 +2,26 @@ spring:
   config:
     import: optional:file:.env.local[.properties]
 
-  flyway:
-    enabled: false
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/khutir_craft}
+    username: ${SPRING_DATASOURCE_USERNAME:postgres}
+    password: ${SPRING_DATASOURCE_PASSWORD:postgres}
 
   jpa:
     generate-ddl: true
     hibernate:
-      ddl-auto: create
+      # ACHTUNG!!! keep `ddl-auto: update` for local profile.
+      # we don't want spring to re-create tables from scratch
+      # every time we start it: https://stackoverflow.com/a/75228882
+      ddl-auto: update
     properties:
       hibernate:
         show-sql: true
         format_sql: true
+
+  flyway:
+    enabled: false
 
   mail:
     host: localhost
@@ -24,6 +33,10 @@ spring:
           starttls:
             enable: false
 
+jwt:
+  secret: ${JWT_SECRET:dummy-secret-phrase}
+  expiration: ${JWT_EXPIRATION:600000}
+
 logging:
   level:
     root: INFO
@@ -34,4 +47,4 @@ logging:
 
 storage:
   local:
-    base-path: ./uploads
+    base-path: ${LOCAL_STORAGE_BASEPATH:'./uploads'}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,17 @@ spring:
     ansi:
       enabled: ALWAYS
 
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+
   flyway:
     enabled: true
     locations: classpath:db/migration
@@ -22,19 +33,6 @@ spring:
       role: ${FLYWAY_ROLE}
       enabled: ${FLYWAY_ENABLED}
       confirmed: ${FLYWAY_CONFIRMED}
-
-
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-
-
-  jpa:
-    hibernate:
-      ddl-auto: none
-    open-in-view: false
 
   mail:
     host: ${MAIL_HOST}
@@ -58,8 +56,6 @@ jwt:
   expiration: ${JWT_EXPIRATION}
 
 logging:
-  pattern:
-    dateformat: 'yyyy-MM-dd hh:mm:ss.SSS'
   level:
     root: WARN
     com:
@@ -78,8 +74,8 @@ management:
       export:
         enabled: true
 
-
 server:
   port: 8080
   error:
-    include-message: always
+    include-message: ALWAYS
+    include-stacktrace: NEVER


### PR DESCRIPTION
- refactor docker compose so that it could be used locally and ran in Docker without setting up environment variables. `.env.local` file still can be used to replace defaults.
- refactor naming convention for Storage classes.
- refactor naming for `containers`, `volume`, `docker compose group`

  ![image](https://github.com/user-attachments/assets/ec053747-146b-40df-bddb-beb65defc912)
