### PR TITLE
devops: refactor application config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 
 # Market Place local
 uploads/
+logs/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,8 +10,10 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - ../.env
-      - ../.env.local
+      - path: ../.env
+        required: false
+      - path: ../.env.local
+        required: false
     build:
       context: ../
       dockerfile: docker/Dockerfile

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,81 +1,11 @@
-spring:
-  application:
-    name: ${SPRING_APPLICATION_NAME:@artifactId@}
-
-  config:
-    import: optional:file:.env[.properties]
-
-  output:
-    ansi:
-      enabled: ALWAYS
-
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-
-  jpa:
-    hibernate:
-      ddl-auto: none
-    open-in-view: false
-
-  flyway:
-    enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
-    placeholders:
-      email: ${FLYWAY_EMAIL}
-      password: ${FLYWAY_PASSWORD}
-      role: ${FLYWAY_ROLE}
-      enabled: ${FLYWAY_ENABLED}
-      confirmed: ${FLYWAY_CONFIRMED}
-
-  mail:
-    host: ${MAIL_HOST}
-    port: ${MAIL_PORT}
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-
-cloudinary:
-  cloud_name: ${CLOUDINARY_CLOUD_NAME}
-  api_key: ${CLOUDINARY_API_KEY}
-  api_secret: ${CLOUDINARY_API_SECRET}
-
-jwt:
-  secret: ${JWT_SECRET}
-  expiration: ${JWT_EXPIRATION}
-
 logging:
   level:
-    root: WARN
+    root: INFO
     com:
-      khutircraftubackend: INFO
+      khutircraftubackend: DEBUG
 
 management:
-  endpoints:
-    web:
-      exposure:
-        include: "info, loggers, health, auditevents, logfile, metrics, sessions"
   endpoint:
     logfile:
       enabled: true
       external-file: ${ACTUATOR_LOGFILE}
-    health:
-      show-details: always
-  prometheus:
-    metrics:
-      export:
-        enabled: true
-
-server:
-  port: 8080
-  error:
-    include-message: ALWAYS
-    include-stacktrace: NEVER

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,14 +14,14 @@ spring:
       # ACHTUNG!!! keep `ddl-auto: update` for local profile.
       # we don't want spring to re-create tables from scratch
       # every time we start it: https://stackoverflow.com/a/75228882
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         show-sql: true
         format_sql: true
 
   flyway:
-    enabled: true
+    enabled: false
 
   mail:
     host: localhost
@@ -37,13 +37,13 @@ jwt:
   secret: ${JWT_SECRET:dummy-secret-phrase}
   expiration: ${JWT_EXPIRATION:600000}
 
-#logging:
-#  level:
-#    root: INFO
-#    com:
-#      khutircraftubackend: DEBUG
-#  file:
-#    name: logs/latest.log
+logging:
+  level:
+    root: INFO
+    com:
+      khutircraftubackend: DEBUG
+  file:
+    name: logs/latest.log
 
 storage:
   local:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,4 +9,4 @@ spring:
     hibernate:
       ddl-auto: update
 jwt:
-  expiration: 600_000
+  expiration: 600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
 
   config:
     import: optional:file:.env[.properties]
-#
-#  profiles:
-#    default: dev
+
+  profiles:
+    default: local
 
   output:
     ansi:
@@ -57,9 +57,9 @@ jwt:
 
 logging:
   level:
-    root: INFO
+    root: WARN
     com:
-      khutircraftubackend: DEBUG
+      khutircraftubackend: INFO
   file:
     name: logs/latest.log
 


### PR DESCRIPTION
refactoring external application configuration in yaml files
- default profile for our project should be `local` at the moment
- other `application-<whatever>.yml` files should only override existing config parameters in the main `application.yml` file or add new parameters. 
we should avoid duplicating the same parameters in multiple places